### PR TITLE
Add FastAPI prototype for portfolio weighting and KIS orders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+KIS_BASE_URL=https://openapivts.koreainvestment.com:29443
+KIS_APP_KEY=your_appkey
+KIS_APP_SECRET=your_appsecret
+KIS_CANO=12345678
+KIS_ACNT_PRDT_CD=01
+KIS_CUSTTYPE=P
+KIS_MODE=virtual
+TOKEN_TTL_STRATEGY=short
+LOG_LEVEL=INFO
+KIS_MOCK=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# kb-
+# 나만의 펀드 데모
+
+간단한 포트폴리오 비중 추천 및 KIS 증권 주문 데모입니다. FastAPI로 구현되며 Render Web Service 배포를 목표로 합니다.
+
+## 실행 방법
+
+```bash
+# 환경설정
+cp .env.example .env  # 필요 시 값 수정
+
+# 의존성 설치
+pip install -r requirements.txt
+
+# 서버 실행
+uvicorn app.main:app --reload
+```
+
+## 주요 기능
+- `/` 단일 페이지에서 환경설정과 포트폴리오 입력
+- `/api/health` 헬스 체크
+- `/api/kis/token` 토큰 발급 (메모리 캐시)
+- `/api/quotes/daily` 일자별 시세 조회 (모드에 따라 KIS 또는 Mock)
+- `/api/portfolio/weights` 종목 비중 추천
+- `/api/orders/preview` 주문 프리뷰 생성
+- `/api/orders/execute` 모의 주문 실행
+
+## Render 배포
+1. 이 저장소를 Fork 후 Render에서 새 Web Service 생성
+2. Docker 또는 Python 환경 선택 후 `uvicorn app.main:app --host 0.0.0.0 --port $PORT` 명령으로 실행
+3. Environment Variables 설정
+   - `KIS_APP_KEY`, `KIS_APP_SECRET` 등 `.env.example` 참고
+   - `KIS_MODE`를 `real`로 변경하면 실전 도메인과 TR이 사용됩니다.
+   - `KIS_MOCK=1`일 경우 외부 호출 없이 Mock 데이터로 동작합니다.
+
+## 테스트용 스텁
+`KIS_MOCK=1`로 설정하면 가격조회 및 주문이 모두 Mock 데이터로 처리되어 KIS 계정이 없어도 동작을 확인할 수 있습니다.
+
+## 기타
+- `api.http`: REST Client 플러그인으로 테스트 가능한 예시 요청 모음
+- `demo.py`: 로컬 서버와 상호작용하는 간단한 스크립트
+

--- a/api.http
+++ b/api.http
@@ -1,0 +1,26 @@
+### Health
+GET http://localhost:8000/api/health
+
+### Get token (mock)
+POST http://localhost:8000/api/kis/token
+Content-Type: application/json
+
+{
+  "appkey": "demo",
+  "appsecret": "demo",
+  "mode": "virtual"
+}
+
+### Portfolio weights
+POST http://localhost:8000/api/portfolio/weights
+Content-Type: application/json
+
+{
+  "total_cash": 1000000,
+  "items": [
+    {"symbol": "005930", "reason": "핵심 보유"},
+    {"symbol": "000660", "reason": "장기 투자"}
+  ],
+  "initial_buy_ratio": 0.5,
+  "discount_rate": 0.03
+}

--- a/app/kis_client.py
+++ b/app/kis_client.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import httpx
+import hashlib
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+class KISClient:
+    def __init__(self) -> None:
+        self.base_url = os.getenv(
+            "KIS_BASE_URL", "https://openapivts.koreainvestment.com:29443"
+        )
+        self.appkey = os.getenv("KIS_APP_KEY", "")
+        self.appsecret = os.getenv("KIS_APP_SECRET", "")
+        self.cano = os.getenv("KIS_CANO", "")
+        self.acnt_prdt_cd = os.getenv("KIS_ACNT_PRDT_CD", "")
+        self.custtype = os.getenv("KIS_CUSTTYPE", "P")
+        self.mode = os.getenv("KIS_MODE", "virtual")
+        self.mock = os.getenv("KIS_MOCK", "0") == "1"
+        self.token: Optional[str] = None
+        self.expires: datetime = datetime.min
+        self.token_strategy = os.getenv("TOKEN_TTL_STRATEGY", "short")
+
+    async def get_access_token(self, appkey: Optional[str] = None, appsecret: Optional[str] = None) -> Dict[str, Any]:
+        if appkey:
+            self.appkey = appkey
+        if appsecret:
+            self.appsecret = appsecret
+        now = datetime.utcnow()
+        if self.token and now < self.expires:
+            return {"access_token": self.token, "expires_at": self.expires}
+        if self.mock:
+            self.token = "MOCK_TOKEN"
+            ttl = 24 if self.token_strategy == "short" else 24 * 90
+            self.expires = now + timedelta(hours=ttl - 1)
+            return {"access_token": self.token, "expires_at": self.expires}
+
+        url = f"{self.base_url}/oauth2/tokenP"
+        data = {"grant_type": "client_credentials", "appkey": self.appkey, "appsecret": self.appsecret}
+        headers = {"content-type": "application/json"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=data, headers=headers)
+        if resp.status_code != 200:
+            logger.error("token error %s %s", resp.status_code, resp.text)
+            raise httpx.HTTPStatusError("token error", request=resp.request, response=resp)
+        res = resp.json()
+        self.token = res.get("access_token")
+        ttl = 24 if self.token_strategy == "short" else 24 * 90
+        self.expires = now + timedelta(hours=ttl - 1)
+        return {"access_token": self.token, "expires_at": self.expires}
+
+    def hashkey(self, body: Dict[str, Any]) -> str:
+        payload = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    async def headers_for(self, tr_id: str, is_post: bool = False, body: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        token_info = await self.get_access_token()
+        headers = {
+            "authorization": f"Bearer {token_info['access_token']}",
+            "appkey": self.appkey,
+            "appsecret": self.appsecret,
+            "tr_id": tr_id,
+            "custtype": self.custtype,
+            "content-type": "application/json; charset=UTF-8",
+        }
+        if is_post and body is not None:
+            headers["hashkey"] = self.hashkey(body)
+        return headers
+
+    async def inquire_daily_price(self, symbol: str, start: str, end: str) -> Dict[str, Any]:
+        if self.mock:
+            price = 50000 + (int(symbol[-2:]) * 10)
+            today = datetime.today().strftime("%Y%m%d")
+            return {
+                "output2": [
+                    {
+                        "stck_bsop_date": today,
+                        "stck_oprc": price,
+                        "stck_hgpr": price,
+                        "stck_lwpr": price,
+                        "stck_clpr": price,
+                        "acml_vol": 0,
+                    }
+                ]
+            }
+        url = f"{self.base_url}/uapi/domestic-stock/v1/quotations/inquire-daily-price"
+        params = {"fid_cond_mrkt_div_code": "J", "fid_input_iscd": symbol, "fid_period_div_code": "D", "fid_org_adj_prc": "0"}
+        headers = await self.headers_for("FHKST01010400")
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(url, params=params, headers=headers)
+        if resp.status_code != 200:
+            logger.error("quote error %s %s", resp.status_code, resp.text)
+            raise httpx.HTTPStatusError("quote error", request=resp.request, response=resp)
+        return resp.json()
+
+    async def order_cash(self, pdno: str, qty: int, price: str, side: str, ord_dvsn: str) -> Dict[str, Any]:
+        tr_base = "TTTC" if self.mode == "real" else "VTTC"
+        tr_id = f"{tr_base}0802U" if side == "buy" else f"{tr_base}0801U"
+        body = {
+            "CANO": self.cano,
+            "ACNT_PRDT_CD": self.acnt_prdt_cd,
+            "PDNO": pdno,
+            "ORD_DVSN": ord_dvsn,
+            "ORD_QTY": str(qty),
+            "ORD_UNPR": price,
+            "CMA_EVLU_AMT_ICLD_YN": "N",
+            "OVRS_ICLD_YN": "N",
+        }
+        if self.mock:
+            return {"mock": True, "tr_id": tr_id, "body": body}
+        url = f"{self.base_url}/uapi/domestic-stock/v1/trading/order-cash"
+        headers = await self.headers_for(tr_id, is_post=True, body=body)
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=body, headers=headers)
+        if resp.status_code != 200:
+            logger.error("order error %s %s", resp.status_code, resp.text)
+            raise httpx.HTTPStatusError("order error", request=resp.request, response=resp)
+        return resp.json()
+
+
+kis_client = KISClient()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import logging
+import os
+from math import floor
+from typing import List
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.templating import Jinja2Templates
+
+from .schemas import (
+    OrderExecuteRequest,
+    OrderExecuteResponse,
+    OrderPreviewItem,
+    OrderPreviewRequest,
+    OrderPreviewResponse,
+    TokenRequest,
+    TokenResponse,
+    WeightsRequest,
+    WeightsResponse,
+)
+from .weights import calculate_weights
+from .kis_client import kis_client
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@app.get("/")
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/api/health")
+async def health():
+    return {"mode": kis_client.mode, "base_url": kis_client.base_url}
+
+
+@app.post("/api/kis/token", response_model=TokenResponse)
+async def api_token(req: TokenRequest):
+    if req.mode:
+        kis_client.mode = req.mode
+    try:
+        data = await kis_client.get_access_token(req.appkey, req.appsecret)
+    except Exception as e:  # broad catch to return json
+        raise HTTPException(status_code=500, detail=str(e))
+    return TokenResponse(access_token=data["access_token"], expires_at=data["expires_at"])
+
+
+@app.get("/api/quotes/daily", response_model=QuoteResponse)
+async def quotes_daily(symbol: str, start: str, end: str):
+    try:
+        data = await kis_client.inquire_daily_price(symbol, start, end)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    prices = [
+        {
+            "date": item.get("stck_bsop_date"),
+            "open": float(item.get("stck_oprc")),
+            "high": float(item.get("stck_hgpr")),
+            "low": float(item.get("stck_lwpr")),
+            "close": float(item.get("stck_clpr")),
+            "volume": float(item.get("acml_vol")),
+        }
+        for item in data.get("output2", [])
+    ]
+    return QuoteResponse(symbol=symbol, prices=prices)
+
+
+@app.post("/api/portfolio/weights", response_model=WeightsResponse)
+async def portfolio_weights(req: WeightsRequest):
+    prices = {}
+    for item in req.items:
+        try:
+            data = await kis_client.inquire_daily_price(item.symbol, "", "")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        price = float(data.get("output2", [{}])[0].get("stck_clpr", 0))
+        prices[item.symbol] = price
+    result = calculate_weights(req, prices)
+    return result
+
+
+@app.post("/api/orders/preview", response_model=OrderPreviewResponse)
+async def order_preview(req: OrderPreviewRequest):
+    items: List[OrderPreviewItem] = []
+    total_needed = 0.0
+    for r in req.results:
+        try:
+            data = await kis_client.inquire_daily_price(r.symbol, "", "")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+        price = float(data.get("output2", [{}])[0].get("stck_clpr", 0))
+        qty_market = floor(r.initial_buy_cash / price) if price else 0
+        qty_limit = floor(r.dca_cash / r.limit_price_hint) if r.limit_price_hint else 0
+        cash = qty_market * price + qty_limit * r.limit_price_hint
+        total_needed += cash
+        items.append(
+            OrderPreviewItem(
+                symbol=r.symbol,
+                weight=r.weight,
+                price=price,
+                qty_market=qty_market,
+                qty_limit=qty_limit,
+                limit_price=r.limit_price_hint,
+                cash_needed=round(cash, 2),
+            )
+        )
+    return OrderPreviewResponse(items=items, total_cash_needed=round(total_needed, 2))
+
+
+@app.post("/api/orders/execute", response_model=OrderExecuteResponse)
+async def order_execute(req: OrderExecuteRequest):
+    results = []
+    for item in req.items:
+        try:
+            if item.qty_market > 0:
+                resp_market = await kis_client.order_cash(
+                    pdno=item.symbol, qty=item.qty_market, price="0", side="buy", ord_dvsn="01"
+                )
+                results.append(
+                    {
+                        "symbol": item.symbol,
+                        "order_type": "market",
+                        "qty": item.qty_market,
+                        "price": 0,
+                        "response": resp_market,
+                    }
+                )
+            if item.qty_limit > 0:
+                resp_limit = await kis_client.order_cash(
+                    pdno=item.symbol,
+                    qty=item.qty_limit,
+                    price=str(item.limit_price),
+                    side="buy",
+                    ord_dvsn="00",
+                )
+                results.append(
+                    {
+                        "symbol": item.symbol,
+                        "order_type": "limit",
+                        "qty": item.qty_limit,
+                        "price": item.limit_price,
+                        "response": resp_limit,
+                    }
+                )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    return OrderExecuteResponse(results=results)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class TokenRequest(BaseModel):
+    appkey: Optional[str] = None
+    appsecret: Optional[str] = None
+    mode: Optional[str] = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    expires_at: datetime
+
+
+class QuoteRequest(BaseModel):
+    symbol: str
+    start: str
+    end: str
+
+
+class OHLCV(BaseModel):
+    date: str = Field(..., description="YYYYMMDD")
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class QuoteResponse(BaseModel):
+    symbol: str
+    prices: List[OHLCV]
+
+
+class PortfolioItem(BaseModel):
+    symbol: str
+    reason: str
+
+
+class WeightsRequest(BaseModel):
+    total_cash: float = Field(..., gt=0)
+    items: List[PortfolioItem]
+    initial_buy_ratio: float = 0.5
+    discount_rate: float = 0.03
+
+
+class WeightResult(BaseModel):
+    symbol: str
+    weight: float
+    initial_buy_cash: float
+    dca_cash: float
+    limit_price_hint: float
+
+
+class WeightsResponse(BaseModel):
+    results: List[WeightResult]
+
+
+class OrderPreviewRequest(WeightsResponse):
+    total_cash: float
+
+
+class OrderPreviewItem(BaseModel):
+    symbol: str
+    weight: float
+    price: float
+    qty_market: int
+    qty_limit: int
+    limit_price: float
+    cash_needed: float
+
+
+class OrderPreviewResponse(BaseModel):
+    items: List[OrderPreviewItem]
+    total_cash_needed: float
+
+
+class OrderExecuteRequest(OrderPreviewResponse):
+    pass
+
+
+class OrderResult(BaseModel):
+    symbol: str
+    order_type: str
+    qty: int
+    price: float
+    response: dict
+
+
+class OrderExecuteResponse(BaseModel):
+    results: List[OrderResult]

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8" />
+<title>나만의 펀드</title>
+</head>
+<body>
+<h1>나만의 펀드</h1>
+<section>
+  <h3>환경설정</h3>
+  <label>모드
+    <select id="mode">
+      <option value="virtual">모의</option>
+      <option value="real">실전</option>
+    </select>
+  </label>
+  <label>App Key <input id="appkey" autocomplete="off" /></label>
+  <label>App Secret <input id="appsecret" type="password" autocomplete="off" /></label>
+  <label>CANO <input id="cano" autocomplete="off" /></label>
+  <label>ACNT_PRDT_CD <input id="acnt" autocomplete="off" /></label>
+  <label>HTS ID <input id="hts" autocomplete="off" /></label>
+</section>
+
+<section>
+  <h3>포트폴리오 입력</h3>
+  <label>총 투자금 <input id="total_cash" type="number" value="1000000" /></label>
+  <button type="button" onclick="addRow()">종목 추가</button>
+  <table id="items">
+    <tr><th>종목코드</th><th>투자 이유</th></tr>
+  </table>
+  <label>초기매수비중 <input id="init_ratio" type="number" step="0.01" value="0.5" /></label>
+  <label>잔여분 지정가 할인률 <input id="discount" type="number" step="0.01" value="0.03" /></label>
+  <label><input type="checkbox" id="buy_etf" /> 남는 현금 단기채 ETF/CMA</label>
+</section>
+
+<button id="calc-btn">비중 추천 → 미리보기</button>
+<button id="exec-btn" style="display:none;">주문 실행(모의)</button>
+
+<div id="weights"></div>
+<div id="preview"></div>
+<div id="execute"></div>
+
+<script>
+let lastPreview = null;
+function addRow(){
+  const table=document.getElementById('items');
+  const row=document.createElement('tr');
+  row.innerHTML='<td><input name="symbol" autocomplete="off" /></td><td><input name="reason" style="width:300px" /></td>';
+  table.appendChild(row);
+}
+addRow();
+addRow();
+
+document.getElementById('calc-btn').addEventListener('click', async ()=>{
+  const mode=document.getElementById('mode').value;
+  const appkey=document.getElementById('appkey').value;
+  const appsecret=document.getElementById('appsecret').value;
+  await fetch('/api/kis/token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({appkey,appsecret,mode})});
+  document.getElementById('appkey').value='';
+  document.getElementById('appsecret').value='';
+
+  const rows=document.querySelectorAll('#items tr');
+  const items=[];
+  rows.forEach((row,i)=>{
+    if(i===0) return;
+    const symbol=row.querySelector('input[name="symbol"]').value;
+    const reason=row.querySelector('input[name="reason"]').value;
+    if(symbol) items.push({symbol,reason});
+  });
+  const total_cash=parseFloat(document.getElementById('total_cash').value);
+  const initial_buy_ratio=parseFloat(document.getElementById('init_ratio').value);
+  const discount_rate=parseFloat(document.getElementById('discount').value);
+
+  const weightRes=await fetch('/api/portfolio/weights',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({total_cash,items,initial_buy_ratio,discount_rate})}).then(r=>r.json());
+  let whtml='<h3>비중 결과</h3><table><tr><th>종목</th><th>비중</th><th>초기</th><th>잔여</th><th>지정가</th></tr>';
+  weightRes.results.forEach(r=>{whtml+=`<tr><td>${r.symbol}</td><td>${(r.weight*100).toFixed(2)}%</td><td>${r.initial_buy_cash}</td><td>${r.dca_cash}</td><td>${r.limit_price_hint}</td></tr>`});
+  whtml+='</table>';
+  document.getElementById('weights').innerHTML=whtml;
+
+  const previewReq={results:weightRes.results,total_cash};
+  const previewRes=await fetch('/api/orders/preview',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(previewReq)}).then(r=>r.json());
+  lastPreview=previewRes;
+  let phtml='<h3>주문 프리뷰</h3><table><tr><th>종목</th><th>시장가수량</th><th>지정가수량</th><th>지정가</th><th>필요현금</th></tr>';
+  previewRes.items.forEach(i=>{phtml+=`<tr><td>${i.symbol}</td><td>${i.qty_market}</td><td>${i.qty_limit}</td><td>${i.limit_price}</td><td>${i.cash_needed}</td></tr>`});
+  phtml+='</table>';
+  document.getElementById('preview').innerHTML=phtml;
+  document.getElementById('exec-btn').style.display='inline';
+});
+
+document.getElementById('exec-btn').addEventListener('click', async ()=>{
+  if(!lastPreview) return;
+  const res=await fetch('/api/orders/execute',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(lastPreview)}).then(r=>r.json());
+  let html='<h3>주문 결과</h3><pre>'+JSON.stringify(res, null, 2)+'</pre>';
+  document.getElementById('execute').innerHTML=html;
+});
+</script>
+</body>
+</html>

--- a/app/weights.py
+++ b/app/weights.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import List
+
+from .schemas import PortfolioItem, WeightResult, WeightsRequest, WeightsResponse
+
+KEYWORDS = ["핵심", "최우선", "강한확신", "장기"]
+
+
+def calculate_weights(req: WeightsRequest, prices: dict[str, float]) -> WeightsResponse:
+    n = len(req.items)
+    if n == 0:
+        return WeightsResponse(results=[])
+
+    base = 1 / n
+    weights = []
+    for item in req.items:
+        w = base
+        if any(k in item.reason for k in KEYWORDS):
+            w += 0.05
+        weights.append([item.symbol, w])
+
+    # normalize
+    total = sum(w for _, w in weights)
+    weights = [[sym, w / total] for sym, w in weights]
+
+    # clipping
+    clipped = []
+    for sym, w in weights:
+        w = max(0.10, min(0.40, w))
+        clipped.append([sym, w])
+    # renormalize
+    total = sum(w for _, w in clipped)
+    clipped = [[sym, w / total] for sym, w in clipped]
+
+    results: List[WeightResult] = []
+    for sym, w in clipped:
+        price = prices.get(sym, 0)
+        initial_cash = req.total_cash * w * req.initial_buy_ratio
+        dca_cash = req.total_cash * w * (1 - req.initial_buy_ratio)
+        limit_price = price * (1 - req.discount_rate) if price else 0
+        results.append(
+            WeightResult(
+                symbol=sym,
+                weight=round(w, 4),
+                initial_buy_cash=round(initial_cash, 2),
+                dca_cash=round(dca_cash, 2),
+                limit_price_hint=round(limit_price, 2),
+            )
+        )
+
+    return WeightsResponse(results=results)

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,21 @@
+import json
+import requests
+
+BASE = "http://localhost:8000"
+
+# get token (mock)
+requests.post(f"{BASE}/api/kis/token", json={"appkey": "demo", "appsecret": "demo", "mode": "virtual"})
+
+payload = {
+    "total_cash": 1000000,
+    "items": [
+        {"symbol": "005930", "reason": "핵심 보유"},
+        {"symbol": "000660", "reason": "장기 투자"},
+    ],
+    "initial_buy_ratio": 0.5,
+    "discount_rate": 0.03,
+}
+weights = requests.post(f"{BASE}/api/portfolio/weights", json=payload).json()
+preview = requests.post(f"{BASE}/api/orders/preview", json={"results": weights["results"], "total_cash": payload["total_cash"]}).json()
+execute = requests.post(f"{BASE}/api/orders/execute", json=preview).json()
+print(json.dumps(execute, indent=2, ensure_ascii=False))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+httpx
+pydantic
+python-dotenv
+Jinja2


### PR DESCRIPTION
## Summary
- implement FastAPI app with KIS client, weight algorithm, and order endpoints
- add simple HTML frontend with portfolio form and preview/execute flow
- include Dockerfile, requirements, .env.example, API examples, and demo script

## Testing
- `python -m py_compile app/*.py demo.py`


------
https://chatgpt.com/codex/tasks/task_e_6890acd018d883219e0d9d538d083206